### PR TITLE
ci: add full OpenCode workflow set

### DIFF
--- a/.github/workflows/opencode-manual.yml
+++ b/.github/workflows/opencode-manual.yml
@@ -1,19 +1,18 @@
-name: OpenCode Comment Tasks
+name: OpenCode Manual Task
 
 env:
   OPENCODE_MODEL: opencode/minimax-m2.5-free
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: Prompt for OpenCode in the Duel repository
+        required: true
+        type: string
 
 jobs:
   opencode:
-    if: |
-      contains(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, '/opencode')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -27,7 +26,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Run OpenCode from comment
+      - name: Run manual OpenCode task
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
@@ -35,3 +34,4 @@ jobs:
         with:
           model: ${{ env.OPENCODE_MODEL }}
           use_github_token: true
+          prompt: ${{ inputs.prompt }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,40 @@
+name: OpenCode PR Review
+
+env:
+  OPENCODE_MODEL: opencode/minimax-m2.5-free
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run OpenCode PR review
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: ${{ env.OPENCODE_MODEL }}
+          use_github_token: true
+          prompt: |
+            Review this pull request for the Duel benchmark repository.
+            Focus on:
+            - benchmark correctness and scoring logic
+            - provider integrations and config safety
+            - replay dataset and report consistency
+            - workflow or documentation regressions
+            Prioritize bugs, behavioral regressions, and missing tests.

--- a/.github/workflows/opencode-scheduled.yml
+++ b/.github/workflows/opencode-scheduled.yml
@@ -1,19 +1,14 @@
-name: OpenCode Comment Tasks
+name: OpenCode Scheduled Sweep
 
 env:
   OPENCODE_MODEL: opencode/minimax-m2.5-free
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
+  schedule:
+    - cron: "0 9 * * 1"
 
 jobs:
   opencode:
-    if: |
-      contains(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, '/opencode')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -27,7 +22,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Run OpenCode from comment
+      - name: Run scheduled OpenCode sweep
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
@@ -35,3 +30,8 @@ jobs:
         with:
           model: ${{ env.OPENCODE_MODEL }}
           use_github_token: true
+          prompt: |
+            Review the Duel repository for stale TODO markers, broken workflow
+            assumptions, and benchmark/report drift.
+            Summarize findings. If you find actionable problems, open an issue
+            with a concise reproduction or cleanup note.

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -1,0 +1,54 @@
+name: OpenCode Issue Triage
+
+env:
+  OPENCODE_MODEL: opencode/minimax-m2.5-free
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Check account age
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const user = await github.rest.users.getByUsername({
+              username: context.payload.issue.user.login
+            });
+            const created = new Date(user.data.created_at);
+            const days = (Date.now() - created) / (1000 * 60 * 60 * 24);
+            return days >= 30;
+          result-encoding: string
+
+      - name: Checkout repository
+        if: steps.check.outputs.result == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run OpenCode issue triage
+        if: steps.check.outputs.result == 'true'
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: ${{ env.OPENCODE_MODEL }}
+          use_github_token: true
+          prompt: |
+            Review this issue for the Duel benchmark repository.
+            If there is a clear fix, explanation, or relevant docs:
+            - summarize likely cause
+            - point to relevant files or commands
+            - suggest next debugging or implementation step
+            If the report is too vague or looks like spam, do not comment.


### PR DESCRIPTION
## Summary
- add the full OpenCode workflow set from the GitHub docs to the default-branch path
- include comment-triggered, PR review, issue triage, scheduled, and manual dispatch workflows
- keep the repository's configured OpenCode model and GitHub token wiring so actions can comment, open issues, and create PRs

## Why
GitHub Actions mostly surfaces workflows from the default branch. This PR makes the documented OpenCode workflows visible and runnable after merge.

## Validation
- workflow YAML parsed locally for all `opencode*.yml` files
- existing GitHub secret `OPENCODE_API_KEY` already present