### PR TITLE
ci: polish OpenCode workflow setup

### DIFF
--- a/.github/workflows/opencode-manual.yml
+++ b/.github/workflows/opencode-manual.yml
@@ -10,6 +10,10 @@ on:
         description: Prompt for OpenCode in the Duel repository
         required: true
         type: string
+      agent:
+        description: Optional primary agent name
+        required: false
+        type: string
 
 jobs:
   opencode:
@@ -33,5 +37,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ env.OPENCODE_MODEL }}
+          agent: ${{ inputs.agent }}
           use_github_token: true
           prompt: ${{ inputs.prompt }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -6,15 +6,16 @@ env:
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   review:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/opencode-scheduled.yml
+++ b/.github/workflows/opencode-scheduled.yml
@@ -6,6 +6,7 @@ env:
 on:
   schedule:
     - cron: "0 9 * * 1"
+  workflow_dispatch:
 
 jobs:
   opencode:

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -6,6 +6,7 @@ env:
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
 
 jobs:
   triage:
@@ -19,6 +20,7 @@ jobs:
       - name: Check account age
         id: check
         uses: actions/github-script@v7
+        if: github.event_name != 'workflow_dispatch'
         with:
           script: |
             const user = await github.rest.users.getByUsername({
@@ -30,14 +32,14 @@ jobs:
           result-encoding: string
 
       - name: Checkout repository
-        if: steps.check.outputs.result == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.result == 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Run OpenCode issue triage
-        if: steps.check.outputs.result == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.check.outputs.result == 'true'
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -8,10 +8,12 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   opencode:
     if: |
+      github.event_name == 'workflow_dispatch' ||
       contains(github.event.comment.body, '/oc') ||
       contains(github.event.comment.body, '/opencode')
     runs-on: ubuntu-latest
@@ -35,3 +37,4 @@ jobs:
         with:
           model: ${{ env.OPENCODE_MODEL }}
           use_github_token: true
+          prompt: ${{ github.event_name == 'workflow_dispatch' && 'Review the current issue or pull request context if present, otherwise summarize repository state and next actions.' || '' }}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,69 @@ Full generated output:
 - per-run JSON artifacts with prompt, answer, latency, and result data
 - markdown leaderboard generation for GitHub-friendly presentation
 - pytest + Ruff + GitHub Actions CI
+- OpenCode GitHub automations for comments, PR review, issue triage, schedules, and manual runs
+
+## OpenCode GitHub
+
+Configured workflows:
+
+| Workflow | Triggers | Purpose |
+| --- | --- | --- |
+| `OpenCode Comment Tasks` | `issue_comment`, `pull_request_review_comment`, `workflow_dispatch` | react to `/oc` and `/opencode` comments |
+| `OpenCode PR Review` | `pull_request`, `workflow_dispatch` | review benchmark PRs automatically |
+| `OpenCode Issue Triage` | `issues`, `workflow_dispatch` | triage new issues with spam guard |
+| `OpenCode Scheduled Sweep` | `schedule`, `workflow_dispatch` | weekly repository sweep |
+| `OpenCode Manual Task` | `workflow_dispatch` | ad hoc OpenCode run from Actions tab |
+
+Secret required:
+
+- `OPENCODE_API_KEY`
+
+Current model:
+
+- `opencode/minimax-m2.5-free`
+
+### Why earlier GitHub Action failed
+
+Earlier `403 Resource not accessible by integration` error came from old default-branch workflow config.
+That version had read-only GitHub permissions and did not pass `GITHUB_TOKEN` to OpenCode, so it could not add reactions or comments.
+
+Current workflows now include:
+
+- `GITHUB_TOKEN`
+- `use_github_token: true`
+- write permissions where OpenCode needs to comment, react, open issues, or create PRs
+
+### Quick trigger tests
+
+1. Issue comment:
+
+```text
+/opencode explain this issue
+```
+
+2. PR review comment on code:
+
+```text
+/oc add error handling here
+```
+
+3. Manual run from Actions tab:
+
+- open `OpenCode Manual Task`
+- set `prompt` to something like `Summarize current benchmark architecture and suggest one missing test.`
+
+4. PR auto-review:
+
+- open or update a PR and check `OpenCode PR Review`
+
+5. Issue triage:
+
+- open a new issue from an account older than 30 days
+
+6. Scheduled sweep:
+
+- wait for cron or trigger `OpenCode Scheduled Sweep` manually
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- fix OpenCode workflow permissions so review/comment actions can post reactions and comments instead of failing with 403 integration errors
- add `workflow_dispatch` coverage across the OpenCode workflow set for easier manual testing from the Actions UI
- document the trigger matrix, required secret, root cause of the earlier failure, and exact smoke-test steps in the README

## Root cause fixed
The earlier GitHub Action failure came from workflows running with read-only GitHub permissions. OpenCode attempted to add a reaction and comment, but the token scope only allowed reads, which caused `Resource not accessible by integration`.

## Validation
- `gh workflow list` now shows all five OpenCode workflows
- local YAML parse passed for all `opencode*.yml` files