### PR TITLE
fix: correct live run result scoring

### DIFF
--- a/src/duel/runner.py
+++ b/src/duel/runner.py
@@ -37,7 +37,7 @@ def run_replay(provider, dataset_path: str) -> RunArtifact:
                 latency_ms=response.latency_ms,
                 correct_choice=question.correct_choice,
                 is_correct=is_correct,
-                transition="complete" if is_correct else "stop",
+                transition="next" if is_correct else "result",
             )
         )
 
@@ -84,7 +84,7 @@ def run_live(provider, config: dict, *, headless: bool = True) -> RunArtifact:
                 transition = client.answer(response.answer or "")
                 result_state = client.read_result() if transition == "result" else None
 
-                is_correct = _infer_live_correctness(index, score, result_state, transition)
+                is_correct = _infer_live_correctness(score, result_state, transition)
                 if is_correct:
                     score += 1
 
@@ -138,7 +138,6 @@ def run_live(provider, config: dict, *, headless: bool = True) -> RunArtifact:
 
 
 def _infer_live_correctness(
-    index: int,
     score: int,
     result_state: ResultState | None,
     transition: str,
@@ -147,8 +146,6 @@ def _infer_live_correctness(
         return True
     if result_state and result_state.score is not None:
         return result_state.score > score
-    if transition == "result" and index == 10:
-        return True
     return False
 
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,4 +1,4 @@
-from src.duel.parsing import format_prompt, normalize_choice
+from src.duel.parsing import choice_to_index, format_prompt, normalize_choice
 
 
 def test_normalize_choice_handles_common_formats():
@@ -6,6 +6,17 @@ def test_normalize_choice_handles_common_formats():
     assert normalize_choice("answer: c") == "C"
     assert normalize_choice("Možnosť D") == "D"
     assert normalize_choice("I think A is correct") == "A"
+
+
+def test_normalize_choice_rejects_empty_or_non_choice_text():
+    assert normalize_choice(None) is None
+    assert normalize_choice("") is None
+    assert normalize_choice("Aloha") is None
+
+
+def test_choice_to_index_maps_normalized_choice():
+    assert choice_to_index("c") == 2
+    assert choice_to_index("invalid") is None
 
 
 def test_format_prompt_normalizes_option_prefixes():

--- a/tests/test_replay_reporting.py
+++ b/tests/test_replay_reporting.py
@@ -1,7 +1,8 @@
 
+from src.duel.browser import ResultState
 from src.duel.providers.offline import BaselineProvider, OracleProvider
 from src.duel.reporting import load_artifacts, write_report
-from src.duel.runner import run_replay
+from src.duel.runner import _infer_live_correctness, run_replay
 from src.duel.storage import save_run_artifact
 
 
@@ -36,3 +37,23 @@ def test_report_generation_aggregates_saved_runs(tmp_path):
     assert '"run_count": 2' in summary
     assert "oracle" in markdown
     assert "baseline" in markdown
+
+
+def test_replay_runner_uses_live_transition_labels():
+    artifact = run_replay(OracleProvider(), "examples/replay_sample.json")
+
+    assert [question.transition for question in artifact.questions] == ["next"] * 5
+
+
+def test_infer_live_correctness_false_when_result_score_does_not_increase():
+    result_state = ResultState(
+        title="Koniec hry",
+        meta="",
+        summary="",
+        message="",
+        time_text="",
+        score=0,
+        max_score=10,
+    )
+
+    assert _infer_live_correctness(0, result_state, "result") is False


### PR DESCRIPTION
## Summary
- fix live-run correctness inference so result screens do not count as correct without a score increase
- align replay transition labels with live run artifacts for consistent reporting semantics
- add regression coverage for live correctness and parsing edge cases

## Verification
- `uv run pytest`
- `uv run ruff check`