### PR TITLE
ci: switch OpenCode workflows to Gemini

### DIFF
--- a/.github/workflows/opencode-manual.yml
+++ b/.github/workflows/opencode-manual.yml
@@ -1,7 +1,7 @@
 name: OpenCode Manual Task
 
 env:
-  OPENCODE_MODEL: opencode/minimax-m2.5-free
+  OPENCODE_MODEL: google/gemini-2.5-flash
 
 on:
   workflow_dispatch:
@@ -33,7 +33,8 @@ jobs:
       - name: Run manual OpenCode task
         uses: anomalyco/opencode/github@latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ env.OPENCODE_MODEL }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,7 +1,7 @@
 name: OpenCode PR Review
 
 env:
-  OPENCODE_MODEL: opencode/minimax-m2.5-free
+  OPENCODE_MODEL: google/gemini-2.5-flash
 
 on:
   pull_request:
@@ -26,7 +26,8 @@ jobs:
       - name: Run OpenCode PR review
         uses: anomalyco/opencode/github@latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ env.OPENCODE_MODEL }}

--- a/.github/workflows/opencode-scheduled.yml
+++ b/.github/workflows/opencode-scheduled.yml
@@ -1,7 +1,7 @@
 name: OpenCode Scheduled Sweep
 
 env:
-  OPENCODE_MODEL: opencode/minimax-m2.5-free
+  OPENCODE_MODEL: google/gemini-2.5-flash
 
 on:
   schedule:
@@ -26,7 +26,8 @@ jobs:
       - name: Run scheduled OpenCode sweep
         uses: anomalyco/opencode/github@latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ env.OPENCODE_MODEL }}

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -1,7 +1,7 @@
 name: OpenCode Issue Triage
 
 env:
-  OPENCODE_MODEL: opencode/minimax-m2.5-free
+  OPENCODE_MODEL: google/gemini-2.5-flash
 
 on:
   issues:
@@ -42,7 +42,8 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || steps.check.outputs.result == 'true'
         uses: anomalyco/opencode/github@latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ env.OPENCODE_MODEL }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,7 +1,7 @@
 name: OpenCode Comment Tasks
 
 env:
-  OPENCODE_MODEL: opencode/minimax-m2.5-free
+  OPENCODE_MODEL: google/gemini-2.5-flash
 
 on:
   issue_comment:
@@ -32,7 +32,8 @@ jobs:
       - name: Run OpenCode from comment
         uses: anomalyco/opencode/github@latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ env.OPENCODE_MODEL }}

--- a/README.md
+++ b/README.md
@@ -77,13 +77,14 @@ Configured workflows:
 | `OpenCode Scheduled Sweep` | `schedule`, `workflow_dispatch` | weekly repository sweep |
 | `OpenCode Manual Task` | `workflow_dispatch` | ad hoc OpenCode run from Actions tab |
 
-Secret required:
+Secrets required:
 
-- `OPENCODE_API_KEY`
+- `GEMINI_API_KEY`
+- `GITHUB_TOKEN` is passed by GitHub Actions so OpenCode can comment, review, react, and open issues/PRs
 
 Current model:
 
-- `opencode/minimax-m2.5-free`
+- `google/gemini-2.5-flash`
 
 ### Why earlier GitHub Action failed
 


### PR DESCRIPTION
## Summary
- switch OpenCode GitHub workflows to `google/gemini-2.5-flash`
- use the repository `GEMINI_API_KEY` secret for model access
- keep `GITHUB_TOKEN` and write permissions so comments, reviews, and issue actions continue to work

## Notes
- this avoids merging the stale branch variants that downgrade permissions or remove GitHub token usage
- README is updated to reflect the new workflow secret and model