### PR TITLE
feat(benchmark): add cost rate overrides and extended replay dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ make test
 uv run duel benchmark --source replay --dataset examples/replay_sample.json --provider baseline
 ```
 
+Larger replay dataset for regression checks:
+
+```bash
+uv run duel benchmark --source replay --dataset examples/replay_extended.json --provider oracle
+```
+
 ### Live benchmark
 
 ```bash
@@ -228,6 +234,18 @@ Main config lives in [`config.yaml`](config.yaml).
 If you need to route Gemini requests through an internal Siemens proxy or a
 custom base URL, add `base_url` under the `providers.gemini` section of the
 config. See `config/siemens.example.yaml` for a sample.
+
+### Cost rate overrides
+
+Override cost estimation in `config.yaml`:
+
+```yaml
+benchmark:
+  cost_rates:
+    gemini-2.5-flash:
+      input_per_million: 0.4
+      output_per_million: 3.0
+```
 
 
 ## Limitations

--- a/examples/replay_extended.json
+++ b/examples/replay_extended.json
@@ -1,0 +1,79 @@
+{
+  "name": "slovak-general-extended",
+  "topic": "vseobecne",
+  "description": "Larger offline dataset for regression checks, report generation, and provider comparison.",
+  "questions": [
+    {
+      "id": "ext-1",
+      "question": "Ktoré mesto je hlavným mestom Slovenska?",
+      "options": ["Košice", "Žilina", "Bratislava", "Nitra"],
+      "correct_choice": "C"
+    },
+    {
+      "id": "ext-2",
+      "question": "Ktorý štátny symbol má tri vrchy a dvojkríž?",
+      "options": ["Vlajka", "Erb", "Pečať", "Hymna"],
+      "correct_choice": "B"
+    },
+    {
+      "id": "ext-3",
+      "question": "Koľko hráčov je na ihrisku za jeden futbalový tím pri výkope?",
+      "options": ["9", "11", "7", "13"],
+      "correct_choice": "B"
+    },
+    {
+      "id": "ext-4",
+      "question": "Ktorá rieka preteká cez Bratislavu?",
+      "options": ["Dunaj", "Váh", "Hron", "Morava"],
+      "correct_choice": "A"
+    },
+    {
+      "id": "ext-5",
+      "question": "Koľko strán má štandardná kocka?",
+      "options": ["4", "5", "7", "6"],
+      "correct_choice": "D"
+    },
+    {
+      "id": "ext-6",
+      "question": "Ktorý deň nasleduje po pondelku?",
+      "options": ["Štvrtok", "Utorok", "Sobota", "Nedeľa"],
+      "correct_choice": "B"
+    },
+    {
+      "id": "ext-7",
+      "question": "Koľko mesiacov má kalendárny rok?",
+      "options": ["10", "11", "12", "13"],
+      "correct_choice": "C"
+    },
+    {
+      "id": "ext-8",
+      "question": "Aká farba vznikne zmiešaním modrej a žltej?",
+      "options": ["Zelená", "Oranžová", "Fialová", "Červená"],
+      "correct_choice": "A"
+    },
+    {
+      "id": "ext-9",
+      "question": "Koľko kontinentov sa bežne rozlišuje?",
+      "options": ["5", "6", "7", "8"],
+      "correct_choice": "C"
+    },
+    {
+      "id": "ext-10",
+      "question": "Ktorý oceán je najväčší?",
+      "options": ["Indický", "Atlantický", "Severný ľadový", "Tichý"],
+      "correct_choice": "D"
+    },
+    {
+      "id": "ext-11",
+      "question": "Aký plyn dýchame najviac pri bežnom dýchaní?",
+      "options": ["Dusík", "Kyslík", "Vodík", "Hélium"],
+      "correct_choice": "B"
+    },
+    {
+      "id": "ext-12",
+      "question": "Ktorý kov je tekutý pri izbovej teplote?",
+      "options": ["Meď", "Železo", "Ortuť", "Hliník"],
+      "correct_choice": "C"
+    }
+  ]
+}

--- a/src/duel/cli.py
+++ b/src/duel/cli.py
@@ -86,7 +86,7 @@ def _run_benchmark(args, config: dict) -> int:
 
     for run_number in range(1, args.runs + 1):
         artifact = (
-            run_replay(provider, args.dataset)
+            run_replay(provider, args.dataset, config=config)
             if args.source == "replay"
             else run_live(provider, config, headless=args.headless)
         )

--- a/src/duel/configuration.py
+++ b/src/duel/configuration.py
@@ -20,6 +20,7 @@ DEFAULT_CONFIG = {
     "benchmark": {
         "default_provider": "openai",
         "artifacts_dir": "reports/runs",
+        "cost_rates": {},
     },
     "providers": {
         "openai": {

--- a/src/duel/costs.py
+++ b/src/duel/costs.py
@@ -1,25 +1,27 @@
-"""Simple cost estimation utilities for provider token usage.
+"""Cost estimation utilities.
 
-This module provides a tiny, easily-overridable rate table and a helper to
-estimate a USD cost for a run based on token usage. Rates are illustrative
-defaults and should be adjusted for accurate billing.
+Uses per-model input/output rates in USD per 1M tokens. Estimates are still
+approximations, but structure matches real provider pricing better than a
+single blended rate.
 """
+
 from __future__ import annotations
 
 from typing import Optional
 
-# Rates are USD per 1000 tokens. These are conservative example defaults and
-# should be adjusted to match real provider billing.
-DEFAULT_RATES: dict[str, float] = {
-    "gemini": 0.005,  # $0.005 per 1k tokens (example)
-    "gpt-4.1-mini": 0.02,
-    "gpt-4.1": 0.06,
-    "gpt-oss": 0.01,
-    "default": 0.0,
+# Rates are USD per 1M tokens.
+# Values chosen to reflect public-style input/output pricing patterns.
+DEFAULT_RATES: dict[str, dict[str, float]] = {
+    "gemini-2.5-flash": {"input_per_million": 0.3, "output_per_million": 2.5},
+    "gemini-2.5-pro": {"input_per_million": 3.5, "output_per_million": 10.5},
+    "gpt-4.1-mini": {"input_per_million": 0.4, "output_per_million": 1.6},
+    "gpt-4.1": {"input_per_million": 2.0, "output_per_million": 8.0},
+    "gpt-oss": {"input_per_million": 0.15, "output_per_million": 0.6},
+    "default": {"input_per_million": 0.0, "output_per_million": 0.0},
 }
 
 
-def _find_rate_for_model(model: Optional[str]) -> float:
+def _find_rate_for_model(model: Optional[str]) -> dict[str, float]:
     if not model:
         return DEFAULT_RATES["default"]
     for key, rate in DEFAULT_RATES.items():
@@ -28,7 +30,12 @@ def _find_rate_for_model(model: Optional[str]) -> float:
     return DEFAULT_RATES["default"]
 
 
-def estimate_cost(token_usage: Optional[dict[str, int]], model: Optional[str]) -> Optional[float]:
+def estimate_cost(
+    token_usage: Optional[dict[str, int]],
+    model: Optional[str],
+    *,
+    rate_overrides: Optional[dict[str, dict[str, float]]] = None,
+) -> Optional[float]:
     """Estimate USD cost given token usage and a model string.
 
     Returns None when insufficient data is provided.
@@ -36,13 +43,24 @@ def estimate_cost(token_usage: Optional[dict[str, int]], model: Optional[str]) -
     if not token_usage:
         return None
 
-    total = token_usage.get("total_tokens")
-    if total is None:
-        # fallback to summing prompt + response/completion tokens
-        prompt = token_usage.get("prompt_tokens", 0)
-        response = token_usage.get("response_tokens", token_usage.get("completion_tokens", 0))
-        total = prompt + response
+    prompt = token_usage.get("prompt_tokens", 0)
+    response = token_usage.get(
+        "response_tokens",
+        token_usage.get("completion_tokens", 0),
+    )
+    if prompt == 0 and response == 0:
+        total = token_usage.get("total_tokens", 0)
+        prompt = total
 
-    rate = _find_rate_for_model(model)
-    cost = (total / 1000.0) * rate
+    rate_table = rate_overrides or DEFAULT_RATES
+    rate = DEFAULT_RATES["default"]
+    if model:
+        for key, value in rate_table.items():
+            if key != "default" and key in model:
+                rate = value
+                break
+
+    input_cost = (prompt / 1_000_000.0) * rate["input_per_million"]
+    output_cost = (response / 1_000_000.0) * rate["output_per_million"]
+    cost = input_cost + output_cost
     return round(cost, 8)

--- a/src/duel/runner.py
+++ b/src/duel/runner.py
@@ -26,7 +26,7 @@ def _aggregate_usage(results: list[QuestionResult]) -> dict[str, int]:
     }
 
 
-def run_replay(provider, dataset_path: str) -> RunArtifact:
+def run_replay(provider, dataset_path: str, config: dict | None = None) -> RunArtifact:
     dataset = load_replay_dataset(dataset_path)
     questions: list[Question] = dataset["questions"]
     started = perf_counter()
@@ -65,7 +65,11 @@ def run_replay(provider, dataset_path: str) -> RunArtifact:
             break
 
     token_usage = _aggregate_usage(results)
-    estimated_cost = estimate_cost(token_usage, provider.model)
+    estimated_cost = estimate_cost(
+        token_usage,
+        provider.model,
+        rate_overrides=(config or {}).get("benchmark", {}).get("cost_rates"),
+    )
 
     return RunArtifact(
         run_id=uuid4().hex[:12],
@@ -145,7 +149,11 @@ def run_live(provider, config: dict, *, headless: bool = True) -> RunArtifact:
             status = "error"
 
     token_usage = _aggregate_usage(results)
-    estimated_cost = estimate_cost(token_usage, provider.model)
+    estimated_cost = estimate_cost(
+        token_usage,
+        provider.model,
+        rate_overrides=config.get("benchmark", {}).get("cost_rates"),
+    )
 
     return RunArtifact(
         run_id=run_id,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -33,3 +33,25 @@ gemini:
     assert config["providers"]["gemini"]["model"] == "gemini-custom"
     assert config["providers"]["gemini"]["api_key"] == "gemini-token"
     assert Path(config["config_path"]) == config_path.resolve()
+
+
+def test_load_config_keeps_cost_rate_overrides(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+benchmark:
+  cost_rates:
+    gemini-2.5-flash:
+      input_per_million: 0.4
+      output_per_million: 3.0
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert config["benchmark"]["cost_rates"]["gemini-2.5-flash"] == {
+        "input_per_million": 0.4,
+        "output_per_million": 3.0,
+    }

--- a/tests/test_provider_usage_and_costs.py
+++ b/tests/test_provider_usage_and_costs.py
@@ -54,3 +54,19 @@ def test_run_replay_aggregates_token_usage_and_cost():
         "total_tokens": 60,
     }
     assert artifact.estimated_cost_usd is not None
+
+
+def test_estimate_cost_uses_separate_input_output_rates():
+    usage = {"prompt_tokens": 1000, "response_tokens": 500, "total_tokens": 1500}
+    cost = estimate_cost(
+        usage,
+        "custom-model",
+        rate_overrides={
+            "custom-model": {
+                "input_per_million": 1.0,
+                "output_per_million": 2.0,
+            }
+        },
+    )
+
+    assert cost == 0.002

--- a/tests/test_replay_reporting.py
+++ b/tests/test_replay_reporting.py
@@ -15,6 +15,15 @@ def test_replay_runner_scores_oracle_dataset():
     assert len(artifact.questions) == 5
 
 
+def test_replay_runner_scores_extended_oracle_dataset():
+    artifact = run_replay(OracleProvider(), "examples/replay_extended.json")
+
+    assert artifact.score == 12
+    assert artifact.max_score == 12
+    assert artifact.status == "completed"
+    assert len(artifact.questions) == 12
+
+
 def test_report_generation_aggregates_saved_runs(tmp_path):
     runs_dir = tmp_path / "runs"
     oracle_artifact = run_replay(OracleProvider(), "examples/replay_sample.json")


### PR DESCRIPTION
## Summary
- replace placeholder blended cost estimates with separate input/output rate tables and config overrides
- add larger replay dataset for stronger offline regression checks and provider comparisons
- add tests and README updates for both paths

## Validation
- uv run ruff check .
- uv run pytest -q