### PR TITLE
docs(contributors): credit opencode contributor branch

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,7 +1,7 @@
 Contributors
 ============
 
-- kovacoj — Maintainer
+- kovacoj / kovacoj1 — Maintainer
 - opencode-agent[bot] — Automated contributor (OpenCode agent)
 
 This project accepts contributions. See CONTRIBUTING.md for guidelines on


### PR DESCRIPTION
## Summary
- preserve current CONTRIBUTORS structure
- carry forward contributor credit from  without merging its stale branch history
- keep maintainer naming consistent with current repo identity

## Why
 diverged from old main and would revert large parts of repository if merged directly. This PR ports only safe contributor credit into current main.